### PR TITLE
Remove restrictions of center statusbar clock + network traffic monitor

### DIFF
--- a/src/com/android/settings/derpfest/statusbar/NetworkTrafficSettings.java
+++ b/src/com/android/settings/derpfest/statusbar/NetworkTrafficSettings.java
@@ -47,8 +47,6 @@ public class NetworkTrafficSettings extends SettingsPreferenceFragment
         int units = Settings.Secure.getInt(resolver,
                 Settings.Secure.NETWORK_TRAFFIC_UNITS, /* Mbps */ 1);
         mNetTrafficUnits.setValue(String.valueOf(units));
-
-        updateForClockConflicts();
     }
 
     @Override
@@ -67,21 +65,6 @@ public class NetworkTrafficSettings extends SettingsPreferenceFragment
     private void updateEnabledStates(boolean enabled) {
         mNetTrafficAutohide.setEnabled(enabled);
         mNetTrafficUnits.setEnabled(enabled);
-    }
-
-    private void updateForClockConflicts() {
-        int clockPosition = Settings.System.getInt(getActivity().getContentResolver(),
-                STATUS_BAR_CLOCK_STYLE, 2);
-
-        if (clockPosition != 1) {
-            return;
-        }
-
-        mNetTraffic.setEnabled(false);
-        Toast.makeText(getActivity(),
-                R.string.network_traffic_disabled_clock,
-                Toast.LENGTH_LONG).show();
-        updateEnabledStates(false);
     }
 
     @Override

--- a/src/com/android/settings/derpfest/statusbar/StatusBarSettings.java
+++ b/src/com/android/settings/derpfest/statusbar/StatusBarSettings.java
@@ -91,28 +91,29 @@ public class StatusBarSettings extends SettingsPreferenceFragment
             mStatusBarAmPm.setSummary(R.string.status_bar_am_pm_info);
         }
 
-        final boolean disallowCenteredClock = mHasCenteredCutout;
+        final boolean isRTL = getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
 
-        // Adjust status bar preferences for RTL
-        if (getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
-            if (disallowCenteredClock) {
-                mStatusBarClock.setEntries(R.array.status_bar_clock_position_entries_notch_rtl);
-                mStatusBarClock.setEntryValues(R.array.status_bar_clock_position_values_notch);
-            } else {
-                mStatusBarClock.setEntries(R.array.status_bar_clock_position_entries_rtl);
-                mStatusBarClock.setEntryValues(R.array.status_bar_clock_position_values);
-            }
-            mQuickPulldown.setEntries(R.array.status_bar_quick_qs_pulldown_entries_rtl);
-        } else {
-            if (disallowCenteredClock) {
-                mStatusBarClock.setEntries(R.array.status_bar_clock_position_entries_notch);
-                mStatusBarClock.setEntryValues(R.array.status_bar_clock_position_values_notch);
-            } else {
-                mStatusBarClock.setEntries(R.array.status_bar_clock_position_entries);
-                mStatusBarClock.setEntryValues(R.array.status_bar_clock_position_values);
-            }
-            mQuickPulldown.setEntries(R.array.status_bar_quick_qs_pulldown_entries);
-        }
+        mStatusBarClock.setEntries(
+            isRTL
+                ? mHasCenteredCutout
+                    ? R.array.status_bar_clock_position_entries_notch_rtl
+                    : R.array.status_bar_clock_position_entries_rtl
+                : mHasCenteredCutout
+                    ? R.array.status_bar_clock_position_entries_notch
+                    : R.array.status_bar_clock_position_entries
+        );
+
+        mStatusBarClock.setEntryValues(
+            mHasCenteredCutout
+                ? R.array.status_bar_clock_position_values_notch
+                : R.array.status_bar_clock_position_values
+        );
+
+        mQuickPulldown.setEntries(
+            isRTL
+                ? R.array.status_bar_quick_qs_pulldown_entries_rtl
+                : R.array.status_bar_quick_qs_pulldown_entries
+        );
     }
 
     @Override
@@ -148,25 +149,6 @@ public class StatusBarSettings extends SettingsPreferenceFragment
                 break;
         }
         mQuickPulldown.setSummary(summary);
-    }
-
-    private void updateNetworkTrafficStatus(int clockPosition) {
-        boolean isClockCentered = clockPosition == 1;
-        mNetworkTrafficPref.setEnabled(!isClockCentered);
-        mNetworkTrafficPref.setSummary(getResources().getString(isClockCentered ?
-                R.string.network_traffic_disabled_clock :
-                R.string.network_traffic_settings_summary
-        ));
-    }
-
-    private int getNetworkTrafficStatus() {
-        return Settings.Secure.getInt(getActivity().getContentResolver(),
-                Settings.Secure.NETWORK_TRAFFIC_MODE, 0);
-    }
-
-    private int getClockPosition() {
-        return Settings.System.getInt(getActivity().getContentResolver(),
-                STATUS_BAR_CLOCK_STYLE, 2);
     }
 
     @Override

--- a/src/com/android/settings/derpfest/statusbar/StatusBarSettings.java
+++ b/src/com/android/settings/derpfest/statusbar/StatusBarSettings.java
@@ -91,7 +91,7 @@ public class StatusBarSettings extends SettingsPreferenceFragment
             mStatusBarAmPm.setSummary(R.string.status_bar_am_pm_info);
         }
 
-        final boolean disallowCenteredClock = mHasCenteredCutout || getNetworkTrafficStatus() != 0;
+        final boolean disallowCenteredClock = mHasCenteredCutout;
 
         // Adjust status bar preferences for RTL
         if (getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
@@ -113,9 +113,6 @@ public class StatusBarSettings extends SettingsPreferenceFragment
             }
             mQuickPulldown.setEntries(R.array.status_bar_quick_qs_pulldown_entries);
         }
-
-        // Disable network traffic preferences if clock is centered in the status bar
-        updateNetworkTrafficStatus(getClockPosition());
     }
 
     @Override
@@ -125,9 +122,6 @@ public class StatusBarSettings extends SettingsPreferenceFragment
         switch (key) {
             case STATUS_BAR_QUICK_QS_PULLDOWN:
                 updateQuickPulldownSummary(value);
-                break;
-            case STATUS_BAR_CLOCK_STYLE:
-                updateNetworkTrafficStatus(value);
                 break;
         }
         return true;


### PR DESCRIPTION
refactored the code and removed redundancies.

Test: Enable center style clock in statusbar and network traffic monitor.
Edge Case: With many statusbar icons, center clock is not overlayed, instead the dot * appears which hints at more icons.

Devices: 
OnePlus 8Pro (instantnoodlep)
Xiaomi Pad 5 (nabu)

Languages:
English - United States (LTR)
Arabic (RTL)

Also tested Quick pull down which was affected by this change in LTR and RTL.